### PR TITLE
Multiple reordering with uniqueness condition can result in integrity errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,6 @@ install:
 script: "make test"
 notifications:
   email: false
-matrix:
-  exclude:
-    - python: "3.3"
-      env: DJANGO='django>=1.7,<1.8'
-    - python: "3.4"
-      env: DJANGO='django>=1.7,<1.8'
 before_install:
   pip install codecov
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ python:
   - "3.3"
   - "3.4"
 env:
-  - DJANGO='django>=1.4,<1.5'
   - DJANGO='django>=1.6,<1.7'
   - DJANGO='django>=1.7,<1.8'
+  - DJANGO='--pre django'
 install:
   - psql -c 'CREATE DATABASE orderable' -U postgres;
   - pip install $DJANGO
@@ -18,9 +18,9 @@ notifications:
 matrix:
   exclude:
     - python: "3.3"
-      env: DJANGO='django>=1.4,<1.5'
+      env: DJANGO='django>=1.7,<1.8'
     - python: "3.4"
-      env: DJANGO='django>=1.4,<1.5'
+      env: DJANGO='django>=1.7,<1.8'
 before_install:
   pip install codecov
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -36,13 +36,6 @@ Subclass the Orderable class: ::
 
 **Note:** If your subclass of Orderable has a Metaclass then make sure it subclasses the Orderable one so the model is sorted by ``sort_order``.
 
-** *Also* Note:** Saving orderable models invokes a fair number of queries and
-in order to avoid race conditions should be run in a transaction. If you're
-using django >= 1.6 we recommend you set `DATABASES['default']['ATOMIC_REQUESTS'] = True` in your
-settings, if you're not yet on django 1.6, we recommend use of
-`TransactionMiddleware`.
-
-
 Subclass the appropriate Orderable admin classes: ::
 
     from orderable.admin import OrderableAdmin, OrderableTabularInline

--- a/orderable/admin.py
+++ b/orderable/admin.py
@@ -40,11 +40,7 @@ class OrderableAdmin(admin.ModelAdmin):
 
     def get_url_name(self):
         meta = self.model._meta
-        try:
-            model_name = meta.model_name
-        except AttributeError:
-            # model_name is called module_name in django < 1.6
-            model_name = meta.module_name
+        model_name = meta.model_name
 
         return '{0}admin_{1}_{2}_reorder'.format(
             self.admin_site.name, meta.app_label, model_name,

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -68,6 +68,7 @@ class Orderable(models.Model):
         ).order_by('-sort_order').first()
 
     def _save(self, objects, old_pos, new_pos):
+        """WARNING: Intensive giggery-pokery zone."""
         to_shift = objects.exclude(pk=self.pk) if self.pk else objects
 
         # If not set, insert at end.
@@ -108,13 +109,7 @@ class Orderable(models.Model):
         self.sort_order = max_obj + 1 if max_obj else 1
 
     def save(self, *args, **kwargs):
-        """
-        Keep the unique order in sync.
-
-        Expects to be run in a transaction to avoid race conditions.
-
-        WARNING: Intensive giggery-pokery zone.
-        """
+        """Keep the unique order in sync."""
         objects = self.get_filtered_manager()
         old_pos = getattr(self, '_original_sort_order', None)
         new_pos = self.sort_order

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import models
+from django.db import models, transaction, IntegrityError
 
 
 class Orderable(models.Model):
@@ -67,6 +67,46 @@ class Orderable(models.Model):
             sort_order__lt=self.sort_order
         ).order_by('-sort_order').first()
 
+    def _save(self, objects, old_pos, new_pos):
+        to_shift = objects.exclude(pk=self.pk) if self.pk else objects
+
+        # If not set, insert at end.
+        if self.sort_order is None:
+            self._move_to_end(objects)
+
+        # New insert.
+        elif not self.pk and not old_pos:
+            # Increment `sort_order` on objects with:
+            #     sort_order > new_pos.
+            to_shift = to_shift.filter(sort_order__gte=self.sort_order)
+            to_shift.update(sort_order=models.F('sort_order') + 1)
+            self.sort_order = new_pos
+
+        # self.sort_order decreased.
+        elif old_pos and new_pos < old_pos:
+            self._move_to_end(objects)
+            super(Orderable, self).save()
+            # Increment `sort_order` on objects with:
+            #     sort_order >= new_pos and sort_order < old_pos
+            to_shift = to_shift.filter(sort_order__gte=new_pos, sort_order__lt=old_pos)
+            to_shift.update(sort_order=models.F('sort_order') + 1)
+            self.sort_order = new_pos
+
+        # self.sort_order increased.
+        elif old_pos and new_pos > old_pos:
+            self._move_to_end(objects)
+            super(Orderable, self).save()
+            # Decrement sort_order on objects with:
+            #     sort_order <= new_pos and sort_order > old_pos.
+            to_shift = to_shift.filter(sort_order__lte=new_pos, sort_order__gt=old_pos)
+            to_shift.update(sort_order=models.F('sort_order') - 1)
+            self.sort_order = new_pos
+
+    def _move_to_end(self, objects):
+        """Temporarily save `self.sort_order` elsewhere (max_obj)."""
+        max_obj = objects.all().aggregate(models.Max('sort_order'))['sort_order__max']
+        self.sort_order = max_obj + 1 if max_obj else 1
+
     def save(self, *args, **kwargs):
         """
         Keep the unique order in sync.
@@ -76,50 +116,16 @@ class Orderable(models.Model):
         WARNING: Intensive giggery-pokery zone.
         """
         objects = self.get_filtered_manager()
-        to_shift = objects.exclude(pk=self.pk) if self.pk else objects
         old_pos = getattr(self, '_original_sort_order', None)
         new_pos = self.sort_order
 
-        def _move_to_end(commit=True):
-            """Temporarily save `self.sort_order` elsewhere (max_obj)."""
-            max_obj = objects.all().aggregate(models.Max('sort_order'))['sort_order__max']
-            self.sort_order = max_obj + 1 if max_obj else 1
-            if commit:
-                super(Orderable, self).save(*args, **kwargs)
-
-        def _move_to_new_pos():
-            """Reset the position of `self.sort_order` before saving."""
-            self.sort_order = new_pos
-
-        # If not set, insert at end.
-        if self.sort_order is None:
-            _move_to_end(commit=False)
-
-        # New insert.
-        elif not self.pk and not old_pos:
-            # Increment `sort_order` on objects with:
-            #     sort_order > new_pos.
-            to_shift = to_shift.filter(sort_order__gte=self.sort_order)
-            to_shift.update(sort_order=models.F('sort_order') + 1)
-            _move_to_new_pos()
-
-        # self.sort_order decreased.
-        elif old_pos and new_pos < old_pos:
-            _move_to_end()
-            # Increment `sort_order` on objects with:
-            #     sort_order >= new_pos and sort_order < old_pos
-            to_shift = to_shift.filter(sort_order__gte=new_pos, sort_order__lt=old_pos)
-            to_shift.update(sort_order=models.F('sort_order') + 1)
-            _move_to_new_pos()
-
-        # self.sort_order increased.
-        elif old_pos and new_pos > old_pos:
-            _move_to_end()
-            # Decrement sort_order on objects with:
-            #     sort_order <= new_pos and sort_order > old_pos.
-            to_shift = to_shift.filter(sort_order__lte=new_pos, sort_order__gt=old_pos)
-            to_shift.update(sort_order=models.F('sort_order') - 1)
-            _move_to_new_pos()
+        try:
+            with transaction.atomic():
+                self._save(objects, old_pos, new_pos)
+        except IntegrityError:
+            with transaction.atomic():
+                old_pos = objects.filter(pk=self.pk).values_list('sort_order', flat=True)[0]
+                self._save(objects, old_pos, new_pos)
 
         # Call the "real" save() method.
         super(Orderable, self).save(*args, **kwargs)

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -27,7 +27,7 @@ class Orderable(models.Model):
             if 'sort_order' in unique_together:
                 unique_fields = list(unique_together)
                 unique_fields.remove('sort_order')
-                return unique_fields
+                return ['%s_id' % f for f in unique_fields]
         return []
 
     def get_filters(self):

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import models, transaction, IntegrityError
+from django.db import IntegrityError, models, transaction
 
 
 class Orderable(models.Model):
@@ -124,7 +124,8 @@ class Orderable(models.Model):
                 self._save(objects, old_pos, new_pos)
         except IntegrityError:
             with transaction.atomic():
-                old_pos = objects.filter(pk=self.pk).values_list('sort_order', flat=True)[0]
+                old_pos = objects.filter(pk=self.pk).values_list(
+                    'sort_order', flat=True)[0]
                 self._save(objects, old_pos, new_pos)
 
         # Call the "real" save() method.

--- a/orderable/tests/factories.py
+++ b/orderable/tests/factories.py
@@ -5,3 +5,9 @@ from . import models
 
 class TaskFactory(factory.DjangoModelFactory):
     FACTORY_FOR = models.Task
+
+
+class SubTaskFactory(factory.DjangoModelFactory):
+    FACTORY_FOR = models.SubTask
+
+    task = factory.SubFactory(TaskFactory)

--- a/orderable/tests/models.py
+++ b/orderable/tests/models.py
@@ -1,5 +1,15 @@
+from django.db import models
+
 from ..models import Orderable
 
 
 class Task(Orderable):
     """A basic orderable model for tests."""
+
+
+class SubTask(Orderable):
+    """An orderable model with unique_together."""
+    task = models.ForeignKey('Task')
+
+    class Meta:
+        unique_together = ('task', 'sort_order')

--- a/orderable/tests/run.py
+++ b/orderable/tests/run.py
@@ -1,5 +1,5 @@
-from argparse import ArgumentParser
 import sys
+from argparse import ArgumentParser
 
 import django
 from django.conf import settings

--- a/orderable/tests/run.py
+++ b/orderable/tests/run.py
@@ -1,3 +1,4 @@
+from argparse import ArgumentParser
 import sys
 
 import django
@@ -21,13 +22,48 @@ if django.VERSION >= (1, 7):
     django.setup()
 
 
+DJANGO_18 = '.'.join(map(str, django.VERSION)) >= '1.8'
+
+
 try:
     from django.test.runner import DiscoverRunner
 except ImportError:
     from discover_runner.runner import DiscoverRunner
 
 
-test_runner = DiscoverRunner(verbosity=1)
-failures = test_runner.run_tests(['orderable'])
-if failures:
-    sys.exit(1)
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Run the Django test suite.")
+    parser.add_argument(
+        '-v', '--verbosity', default=1, type=int, choices=[0, 1, 2, 3],
+        help='Verbosity level; 0=minimal output, 1=normal output, 2=all output')
+    parser.add_argument(
+        '--noinput', action='store_false', dest='interactive', default=True,
+        help='Tells Django to NOT prompt the user for input of any kind.')
+    parser.add_argument(
+        '--failfast', action='store_true', dest='failfast', default=False,
+        help='Tells Django to stop running the test suite after first failed '
+             'test.')
+    parser.add_argument(
+        '-k', '--keepdb', action='store_true', dest='keepdb', default=False,
+        help='Tells Django to preserve the test database between runs.')
+    parser.add_argument(
+        '--reverse', action='store_true', default=False,
+        help='Sort test suites and test cases in opposite order to debug '
+             'test side effects not apparent with normal execution lineup.')
+    parser.add_argument(
+        '--debug-sql', action='store_true', dest='debug_sql', default=False,
+        help='Turn on the SQL query logger within tests (Django 1.8+ only)')
+    options = parser.parse_args()
+    runner_kwargs = {
+        'verbosity': options.verbosity,
+        'interactive': options.interactive,
+        'failfast': options.failfast,
+        'keepdb': options.keepdb,
+        'reverse': options.reverse,
+    }
+    if DJANGO_18:
+        runner_kwargs['debug_sql'] = options.debug_sql
+    test_runner = DiscoverRunner(**runner_kwargs)
+    failures = test_runner.run_tests(['orderable'])
+    if failures:
+        sys.exit(1)

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from . import factories
-from .models import Task
+from .models import Task, SubTask
 
 
 class TestOrderingOnSave(TestCase):
@@ -196,3 +196,15 @@ class TestSubTask(TestCase):
         subtasks[2].save()
         subtasks[3].sort_order = 2
         subtasks[3].save()
+
+    def test_changing_parent(self):
+        """Check changing the unique together parent."""
+        task = factories.TaskFactory.create()
+        task_2 = factories.TaskFactory.create()
+        subtask = factories.SubTaskFactory.create(task=task)
+        subtask_2 = factories.SubTaskFactory.create(task=task_2)
+        self.assertEqual(subtask.sort_order, subtask_2.sort_order)
+        subtask_2 = SubTask.objects.get(pk=subtask_2.pk)
+        subtask_2.task = task
+        subtask_2.save()
+        self.assertSequenceEqual(task.subtask_set.all(), [subtask, subtask_2])

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -139,3 +139,62 @@ class TestOrderingOnSave(TestCase):
         """Zero should be a valid value for sort_order."""
         zero_task = Task.objects.create(sort_order=0)
         self.assertEqual(zero_task.sort_order, 0)
+
+    def test_reordering(self):
+        """Check you can reassign a complete new order.
+
+        This is similar to a formset or the admin reorder view.
+        """
+        tasks = [
+            factories.TaskFactory.create(),
+            factories.TaskFactory.create(),
+            factories.TaskFactory.create(),
+            factories.TaskFactory.create(),
+        ]
+        tasks[0].sort_order = 3
+        tasks[0].save()
+        tasks[1].sort_order = 4
+        tasks[1].save()
+        tasks[2].sort_order = 1
+        tasks[2].save()
+        tasks[3].sort_order = 2
+        tasks[3].save()
+        self.assertSequenceEqual(Task.objects.all(), [
+            tasks[2],
+            tasks[3],
+            tasks[0],
+            tasks[1],
+        ])
+
+
+class TestSubTask(TestCase):
+
+    def test_duplicated_sort_order_on_different_parents(self):
+        task = factories.TaskFactory.create()
+        task_2 = factories.TaskFactory.create()
+        subtask = factories.SubTaskFactory.create(task=task)
+        subtask_2 = factories.SubTaskFactory.create(task=task_2)
+        self.assertEqual(subtask.sort_order, subtask_2.sort_order)
+
+    def test_reordering(self):
+        """Check you can reassign a complete new order.
+
+        This is similar to a formset or the admin reorder view. The subtask
+        version differs importantly because there is a database level
+        uniqueness constraint.
+        """
+        task = factories.TaskFactory.create()
+        subtasks = [
+            factories.SubTaskFactory.create(task=task),
+            factories.SubTaskFactory.create(task=task),
+            factories.SubTaskFactory.create(task=task),
+            factories.SubTaskFactory.create(task=task),
+        ]
+        subtasks[0].sort_order = 3
+        subtasks[0].save()
+        subtasks[1].sort_order = 4
+        subtasks[1].save()
+        subtasks[2].sort_order = 1
+        subtasks[2].save()
+        subtasks[3].sort_order = 2
+        subtasks[3].save()

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -13,7 +13,7 @@ class TestOrderingOnSave(TestCase):
         """Normal saves should avoid giggery pokery."""
         task = Task.objects.create()
 
-        with self.assertNumQueries(1 if DJANGO_16 else 2):
+        with self.assertNumQueries(3 if DJANGO_16 else 4):
             # https://docs.djangoproject.com/en/dev/releases/1.6/#model-save-algorithm-changed
             # Queries on django < 1.6
             #     SELECT
@@ -31,7 +31,7 @@ class TestOrderingOnSave(TestCase):
         """
         old = factories.TaskFactory.create(sort_order=1)
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(4):
             # Queries
             #     Find last position in list
             #     Save to last position in list
@@ -55,7 +55,7 @@ class TestOrderingOnSave(TestCase):
         old_3 = factories.TaskFactory.create(sort_order=3)
 
         # Insert between old_1 and old_2
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(4):
             # Queries:
             #     Bump old_2 to position 3
             #     Save new in position 2
@@ -83,7 +83,7 @@ class TestOrderingOnSave(TestCase):
         item5 = factories.TaskFactory.create(sort_order=5)
 
         # Move item2 to position 4
-        with self.assertNumQueries(4 if DJANGO_16 else 6):
+        with self.assertNumQueries(6 if DJANGO_16 else 8):
             # Queries:
             #     Find end of list
             #     SELECT item2 (on django < 1.6)
@@ -117,7 +117,7 @@ class TestOrderingOnSave(TestCase):
         item5 = factories.TaskFactory.create(sort_order=5)
 
         # Move item4 to position 2
-        with self.assertNumQueries(4 if DJANGO_16 else 6):
+        with self.assertNumQueries(6 if DJANGO_16 else 8):
             # Queries:
             #     Find end of list
             #     SELECT item4 (on django < 1.6)

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -1,11 +1,7 @@
-import django
 from django.test import TestCase
 
 from . import factories
 from .models import Task
-
-
-DJANGO_16 = '.'.join(map(str, django.VERSION)) >= '1.6'
 
 
 class TestOrderingOnSave(TestCase):
@@ -13,13 +9,11 @@ class TestOrderingOnSave(TestCase):
         """Normal saves should avoid giggery pokery."""
         task = Task.objects.create()
 
-        with self.assertNumQueries(3 if DJANGO_16 else 4):
-            # https://docs.djangoproject.com/en/dev/releases/1.6/#model-save-algorithm-changed
-            # Queries on django < 1.6
-            #     SELECT
+        with self.assertNumQueries(3):
+            # Queries:
+            #     SAVEPOINT
             #     UPDATE
-            # Queries on django >= 1.6
-            #     UPDATE
+            #     COMMIT
             task.save()
 
     def test_unspecified_order(self):
@@ -33,8 +27,10 @@ class TestOrderingOnSave(TestCase):
 
         with self.assertNumQueries(4):
             # Queries
+            #     Savepoint
             #     Find last position in list
             #     Save to last position in list
+            #     Commit
             new = factories.TaskFactory.create()
 
         tasks = Task.objects.all()
@@ -57,8 +53,10 @@ class TestOrderingOnSave(TestCase):
         # Insert between old_1 and old_2
         with self.assertNumQueries(4):
             # Queries:
+            #     Savepoint
             #     Bump old_2 to position 3
             #     Save new in position 2
+            #     Commit
             new = factories.TaskFactory.create(sort_order=old_2.sort_order)
 
         tasks = Task.objects.all()
@@ -83,14 +81,14 @@ class TestOrderingOnSave(TestCase):
         item5 = factories.TaskFactory.create(sort_order=5)
 
         # Move item2 to position 4
-        with self.assertNumQueries(6 if DJANGO_16 else 8):
+        with self.assertNumQueries(6):
             # Queries:
+            #     Savepoint
             #     Find end of list
-            #     SELECT item2 (on django < 1.6)
             #     Move item2 to end of list
             #     Shuffle item3 and item4 back by one
-            #     SELECT item2 (on django < 1.6)
             #     Save item2 to new desired position
+            #     Commit
             item2.sort_order = item4.sort_order
             item2.save()
 
@@ -117,14 +115,14 @@ class TestOrderingOnSave(TestCase):
         item5 = factories.TaskFactory.create(sort_order=5)
 
         # Move item4 to position 2
-        with self.assertNumQueries(6 if DJANGO_16 else 8):
+        with self.assertNumQueries(6):
             # Queries:
+            #     Savepoint
             #     Find end of list
-            #     SELECT item4 (on django < 1.6)
             #     Move item4 to end of list
             #     Bump item2 and item3 on by one
-            #     SELECT item4 (on django < 1.6)
             #     Save item4 to new desired position
+            #     Commit
             item4.sort_order = item2.sort_order
             item4.save()
 

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from . import factories
-from .models import Task, SubTask
+from .models import SubTask, Task
 
 
 class TestOrderingOnSave(TestCase):


### PR DESCRIPTION
The old/new position tracking falls over if multiple objects are updated in the same request - which can happen from the admin reorder views. As a result, transaction management is needed to try again if the value is incorrect. As a result of wanting to use `atomic()`, I've removed 1.4 support. 1.4 is near EOL now and 1.8 (in alpha) will be the new LTS so I hope this is not too critical. Might warrant a big number version bump though.

Note that in the process of restructuring the save method I have removed inline methods - these have debatable performance on CPython but are *totally* useless on pypy so Alex will kill me if I don't remove them ;)

As separate work, I've copied some code from django's `runtests.py` which allows you to use `orderable/tests/run.py` like `manage.py test` and pass some helpful options to it.