### PR TITLE
Hosted jQuery and jQuery UI for TabularInline also

### DIFF
--- a/orderable/admin.py
+++ b/orderable/admin.py
@@ -78,3 +78,9 @@ class OrderableTabularInline(admin.TabularInline):
     You'll want your object to subclass incuna.db.models.Orderable.
     """
     template = "admin/edit_inline/orderable_tabular.html"
+
+    class Media:
+        js = (
+            '//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js',
+            '//ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js',
+        )


### PR DESCRIPTION
If OrderableTabularInline was used by itself, jQuery/jQueryUI wasn't loaded. This copies the 'Media' class from OrderableAdmin to OrderableTabularInline.