### PR TITLE
Added extend=False to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ jQuery and jQuery UI are used in the Admin for the draggable UI. You may overrid
 
     class SomeAdminClass(OrderableAdmin):
         class Media:
+            extend = False
             js = (
                 'path/to/jquery.js',
                 'path/to/jquery.ui.js',


### PR DESCRIPTION
When user wishes to override the versions of jQuery and jQuery UI with their own, they need to have extend=False in the nested class. Otherwise the media paths will be simply extended (added to). See https://docs.djangoproject.com/en/1.8/topics/forms/media/#extend

This change adds extend=False to example in README.md