### PR TITLE
Add failing test for saving with a new sort_order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pot
 *.pyc
 local_settings.py
+.hypothesis/

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -97,7 +97,14 @@ class Orderable(models.Model):
             # Increment `sort_order` on objects with:
             #     sort_order >= new_pos and sort_order < old_pos
             to_shift = to_shift.filter(sort_order__gte=new_pos, sort_order__lt=old_pos)
-            to_shift.update(sort_order=models.F('sort_order') + 1)
+            try:
+                with transaction.atomic():
+                    to_shift.update(sort_order=models.F('sort_order') + 1)
+            except IntegrityError:
+                for obj in to_shift.order_by('-sort_order'):
+                    to_shift.filter(pk=obj.pk).update(
+                        sort_order=models.F('sort_order') + 1,
+                    )
             self.sort_order = new_pos
 
         # self.sort_order increased.

--- a/orderable/tests/models.py
+++ b/orderable/tests/models.py
@@ -6,6 +6,9 @@ from ..models import Orderable
 class Task(Orderable):
     """A basic orderable model for tests."""
 
+    def __str__(self):
+        return 'Task {}'.format(self.pk)
+
 
 class SubTask(Orderable):
     """An orderable model with unique_together."""
@@ -13,3 +16,6 @@ class SubTask(Orderable):
 
     class Meta:
         unique_together = ('task', 'sort_order')
+
+    def __str__(self):
+        return 'SubTask {}'.format(self.pk)

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -1,4 +1,4 @@
-from hypothesis import given
+from hypothesis import example, given
 from hypothesis.extra.django import TestCase
 from hypothesis.strategies import integers, lists
 
@@ -215,6 +215,8 @@ class TestSubTask(TestCase):
         self.assertSequenceEqual(task.subtask_set.all(), [subtask, subtask_2])
 
     @given(lists(integers(min_value=1), min_size=1, unique=True))
+    @example([2, 3, 1])
+    @example([2, 3, 4])
     def test_save_subtask_no_errors(self, sort_orders):
         """Ensure Orderable.save does not raise IntegrityError."""
         task = Task.objects.create()

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -215,7 +215,8 @@ class TestSubTask(TestCase):
         self.assertSequenceEqual(task.subtask_set.all(), [subtask, subtask_2])
 
     @given(lists(integers(min_value=1), min_size=1, unique=True))
-    def test_save_subtask(self, sort_orders):
+    def test_save_subtask_no_errors(self, sort_orders):
+        """Ensure Orderable.save does not raise IntegrityError."""
         task = Task.objects.create()
 
         for order in sort_orders:

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -52,12 +52,14 @@ class TestOrderingOnSave(TestCase):
         old_3 = Task.objects.create(sort_order=3)
 
         # Insert between old_1 and old_2
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(6):
             # Queries:
             #     Savepoint
+            #     Savepoint
             #     Bump old_2 to position 3
+            #     Release savepoint
+            #     Release savepoint
             #     Save new in position 2
-            #     Commit
             new = Task.objects.create(sort_order=old_2.sort_order)
 
         tasks = Task.objects.all()

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -214,11 +214,5 @@ class TestSubTask(TestCase):
     def test_save_subtask(self, sort_orders):
         task = Task.objects.create()
 
-        subtasks = [
+        for order in sort_orders:
             SubTask.objects.create(task=task, sort_order=order)
-            for order in sort_orders
-        ]
-
-        subtask = subtasks[-1]
-        subtask.sort_order = 2
-        subtask.save()

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -1,4 +1,6 @@
-from django.test import TestCase
+from hypothesis import given
+from hypothesis.extra.django import TestCase
+from hypothesis.strategies import integers, lists
 
 from .models import SubTask, Task
 
@@ -208,12 +210,13 @@ class TestSubTask(TestCase):
         subtask_2.save()
         self.assertSequenceEqual(task.subtask_set.all(), [subtask, subtask_2])
 
-    def test_save_subtask(self):
+    @given(lists(integers(min_value=1), min_size=1, unique=True))
+    def test_save_subtask(self, sort_orders):
         task = Task.objects.create()
 
         subtasks = [
             SubTask.objects.create(task=task, sort_order=order)
-            for order in [1, 7, 14, 20, 22, 23, 24]
+            for order in sort_orders
         ]
 
         subtask = subtasks[-1]

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -118,14 +118,16 @@ class TestOrderingOnSave(TestCase):
         item5 = Task.objects.create(sort_order=5)
 
         # Move item4 to position 2
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(8):
             # Queries:
             #     Savepoint
             #     Find end of list
             #     Move item4 to end of list
+            #     Savepoint
             #     Bump item2 and item3 on by one
+            #     Release savepoint
+            #     Release savepoint
             #     Save item4 to new desired position
-            #     Commit
             item4.sort_order = item2.sort_order
             item4.save()
 
@@ -217,4 +219,7 @@ class TestSubTask(TestCase):
         task = Task.objects.create()
 
         for order in sort_orders:
-            SubTask.objects.create(task=task, sort_order=order)
+            subtask = SubTask.objects.create(task=task, sort_order=order)
+
+        subtask.sort_order = 2
+        subtask.save()

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -207,3 +207,15 @@ class TestSubTask(TestCase):
         subtask_2.task = task
         subtask_2.save()
         self.assertSequenceEqual(task.subtask_set.all(), [subtask, subtask_2])
+
+    def test_save_subtask(self):
+        task = Task.objects.create()
+
+        subtasks = [
+            SubTask.objects.create(task=task, sort_order=order)
+            for order in [1, 7, 14, 20, 22, 23, 24]
+        ]
+
+        subtask = subtasks[-1]
+        subtask.sort_order = 2
+        subtask.save()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ django-discover-runner==1.0
 flake8==2.2.5
 flake8-docstrings==0.2.1
 flake8-import-order==0.5.3
-psycopg2==2.5.1
+psycopg2==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ django-discover-runner==1.0
 flake8==2.2.5
 flake8-docstrings==0.2.1
 flake8-import-order==0.5.3
+hypothesis==2.0.0
 psycopg2==2.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 [flake8]
 application-import-names = orderable
-ignore = D100,D101,D102,D203,D204
+ignore = D100,D101,D102,D104,D105,D203,D204
 import-order-style = google
 max-complexity = 10
 max-line-length = 90


### PR DESCRIPTION
Fix `IntegrityError` in `Orderable.save` when `qs.update` violates a `unique` constraint.

I used [hypothesis](https://hypothesis.readthedocs.org/en/latest/) because `Orderable.save` is very complex and has potentially many breaking edge-cases hidden away.