### PR TITLE
Add before and after on ordered querysets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - DJANGO='django>=1.6,<1.7'
-  - DJANGO='django>=1.7,<1.8'
   - DJANGO='django>=1.8,<1.9'
   - DJANGO='django>=1.9,<1.10'
   - DJANGO='django>=1.10,<1.11'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ matrix:
      env: DJANGO='django>=1.10,<1.11'
    - python: "3.3"
      env: DJANGO='--pre django'
-   - python: "3.5"
-     env: DJANGO='django>=1.6,<1.7'
-   - python: "3.5"
-     env: DJANGO='django>=1.7,<1.8'
   allow_failures:
     - env: DJANGO='--pre django'
   fast_finish: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+
+Upcoming Changes
+================
+
+* Drop support for django<1.8
+* Added before and after to the querset to return the next item in the set.
+    - example usage: `ordered_queryset.objects.after(ordered_object)`
+
 v4.0.4
 ======
 

--- a/orderable/managers.py
+++ b/orderable/managers.py
@@ -3,5 +3,4 @@ from django.db.models import Manager
 from .querysets import OrderableQueryset
 
 
-class OrderableManager(Manager.from_queryset(OrderableQueryset)):
-    pass
+OrderableManager = Manager.from_queryset(OrderableQueryset)

--- a/orderable/managers.py
+++ b/orderable/managers.py
@@ -1,6 +1,7 @@
-from django.db.models import manager
+from django.db.models import Manager
 
 from .querysets import OrderableQueryset
 
 
-OrderableManager = manager.BaseManager.from_queryset(OrderableQueryset)
+class OrderableManager(Manager.from_queryset(OrderableQueryset)):
+    pass

--- a/orderable/managers.py
+++ b/orderable/managers.py
@@ -2,7 +2,10 @@ from django.db import models
 
 
 class OrderableManager(models.Manager):
-
+    '''
+    Adds additional functionality to `Orderable.objects` allow access to the next and
+    previous ordered object within the queryset.
+    '''
     def before(self, orderable):
         return self.filter(sort_order__lt=orderable.sort_order).last()
 

--- a/orderable/managers.py
+++ b/orderable/managers.py
@@ -3,7 +3,7 @@ from django.db import models
 
 class OrderableManager(models.Manager):
     '''
-    Adds additional functionality to `Orderable.objects` allow access to the next and
+    Adds additional functionality to `Orderable.objects` providing access to the next and
     previous ordered object within the queryset.
     '''
     def before(self, orderable):

--- a/orderable/managers.py
+++ b/orderable/managers.py
@@ -1,14 +1,7 @@
-from django.db import models
+from django.db.models import manager
+
+from .querysets import OrderableQueryset
 
 
-class OrderableManager(models.Manager):
-    """
-    Adds additional functionality to `Orderable.objects`.
-
-    Provides access to the next and previous ordered object within the queryset.
-    """
-    def before(self, orderable):
-        return self.filter(sort_order__lt=orderable.sort_order).last()
-
-    def after(self, orderable):
-        return self.filter(sort_order__gt=orderable.sort_order).first()
+class OrderableManager(manager.BaseManager.from_queryset(OrderableQueryset)):
+    pass

--- a/orderable/managers.py
+++ b/orderable/managers.py
@@ -1,0 +1,10 @@
+from django.db import models
+
+
+class OrderableManager(models.Manager):
+
+    def before(self, orderable):
+        return self.filter(sort_order__lt=orderable.sort_order).last()
+
+    def after(self, orderable):
+        return self.filter(sort_order__gt=orderable.sort_order).first()

--- a/orderable/managers.py
+++ b/orderable/managers.py
@@ -3,5 +3,4 @@ from django.db.models import manager
 from .querysets import OrderableQueryset
 
 
-class OrderableManager(manager.BaseManager.from_queryset(OrderableQueryset)):
-    pass
+OrderableManager = manager.BaseManager.from_queryset(OrderableQueryset)

--- a/orderable/managers.py
+++ b/orderable/managers.py
@@ -2,10 +2,11 @@ from django.db import models
 
 
 class OrderableManager(models.Manager):
-    '''
-    Adds additional functionality to `Orderable.objects` providing access to the next and
-    previous ordered object within the queryset.
-    '''
+    """
+    Adds additional functionality to `Orderable.objects`.
+
+    Provides access to the next and previous ordered object within the queryset.
+    """
     def before(self, orderable):
         return self.filter(sort_order__lt=orderable.sort_order).last()
 

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -36,9 +36,7 @@ class Orderable(models.Model):
 
     def get_filtered_manager(self):
         manager = self.__class__.objects
-        kwargs = {}
-        for field in self.get_unique_fields():
-            kwargs[field] = getattr(self, field)
+        kwargs = {field: getattr(self, field) for field in self.get_unique_fields()}
         return manager.filter(**kwargs)
 
     def next(self):

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -45,13 +45,13 @@ class Orderable(models.Model):
         if not self.sort_order:
             return None
 
-        return self.objects.after(self)
+        return self.get_filtered_manager().after(self)
 
     def prev(self):
         if not self.sort_order:
             return None
 
-        return self.objects.before(self)
+        return self.get_filtered_manager().before(self)
 
     @staticmethod
     def _update(qs):

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -1,6 +1,8 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, models, transaction
 
+from .managers import OrderableManager
+
 
 class Orderable(models.Model):
     """
@@ -16,6 +18,8 @@ class Orderable(models.Model):
     make a nice jquery admin interface.
     """
     sort_order = models.IntegerField(blank=True, db_index=True)
+
+    objects = OrderableManager()
 
     class Meta:
         abstract = True

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -34,38 +34,24 @@ class Orderable(models.Model):
                 return ['%s_id' % f for f in unique_fields]
         return []
 
-    def get_filters(self):
-        """
-        Build a dictionary of filter kwargs.
-
-        Used to select records that are `unique_together`.
-        """
-        unique_fields = self.get_unique_fields()
-        if unique_fields:
-            kwargs = {}
-            for field in unique_fields:
-                kwargs[field] = getattr(self, field)
-            return kwargs
-
     def get_filtered_manager(self):
-        """Return manager which may already have filtered results as needed."""
-        obj = type(self)
-        extra_kwargs = self.get_filters()
-        if extra_kwargs:
-            return obj.objects.filter(**extra_kwargs)
-        return obj.objects
+        manager = self.__class__.objects
+        kwargs = {}
+        for field in self.get_unique_fields():
+            kwargs[field] = getattr(self, field)
+        return manager.filter(**kwargs)
 
     def next(self):
         if not self.sort_order:
             return None
 
-        return self.get_filtered_manager().after(self)
+        return self.objects.after(self)
 
     def prev(self):
         if not self.sort_order:
             return None
 
-        return self.get_filtered_manager().before(self)
+        return self.objects.before(self)
 
     @staticmethod
     def _update(qs):

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -59,17 +59,13 @@ class Orderable(models.Model):
         if not self.sort_order:
             return None
 
-        return self.get_filtered_manager().filter(
-            sort_order__gt=self.sort_order
-        ).order_by('sort_order').first()
+        return self.get_filtered_manager().after(self)
 
     def prev(self):
         if not self.sort_order:
             return None
 
-        return self.get_filtered_manager().filter(
-            sort_order__lt=self.sort_order
-        ).order_by('-sort_order').first()
+        return self.get_filtered_manager().before(self)
 
     @staticmethod
     def _update(qs):

--- a/orderable/querysets.py
+++ b/orderable/querysets.py
@@ -1,0 +1,17 @@
+from django.db import models
+
+
+class OrderableQueryset(models.QuerySet):
+    """
+    Adds additional functionality to `Orderable.objects` and querysets.
+
+    Provides access to the next and previous ordered object within the queryset.
+
+    As a related manager this will provide the filtering automatically. Should you wish
+    to
+    """
+    def before(self, orderable):
+        return self.filter(sort_order__lt=orderable.sort_order).last()
+
+    def after(self, orderable):
+        return self.filter(sort_order__gt=orderable.sort_order).first()

--- a/orderable/tests/test_manager.py
+++ b/orderable/tests/test_manager.py
@@ -6,30 +6,27 @@ from .models import SubTask, Task
 class TestOrderableManager(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.tasks = []
+        tasks = []
         for i in range(3):
             task = Task(sort_order=i)
             task.save()
-            cls.tasks.append(task)
+            tasks.append(task)
+        cls.first_task, cls.middle_task, cls.last_task = tasks
 
     def test_gets_next(self):
-        first_task = self.tasks[0]
-        next_task = Task.objects.after(first_task)
-        self.assertEqual(next_task, self.tasks[1])
+        next_task = Task.objects.after(self.first_task)
+        self.assertEqual(next_task, self.middle_task)
 
     def test_gets_previous(self):
-        last_task = self.tasks[2]
-        previous_task = Task.objects.before(last_task)
-        self.assertEqual(previous_task, self.tasks[1])
+        previous_task = Task.objects.before(self.last_task)
+        self.assertEqual(previous_task, self.middle_task)
 
     def test_returns_none_if_after_on_last(self):
-        last_task = self.tasks[2]
-        next_task = Task.objects.after(last_task)
+        next_task = Task.objects.after(self.last_task)
         self.assertIsNone(next_task)
 
     def test_returns_none_if_previous_on_first(self):
-        first_task = self.tasks[0]
-        previous_task = Task.objects.before(first_task)
+        previous_task = Task.objects.before(self.first_task)
         self.assertIsNone(previous_task)
 
 
@@ -39,28 +36,25 @@ class TestOrderableRelatedManager(TestCase):
         cls.task = Task()
         cls.task.save()
 
-        cls.sub_tasks = []
+        sub_tasks = []
         for i in range(3):
             sub = SubTask(task=cls.task, sort_order=i)
             sub.save()
-            cls.sub_tasks.append(sub)
+            sub_tasks.append(sub)
+        cls.first_sub_task, cls.middle_sub_task, cls.last_sub_task = sub_tasks
 
     def test_gets_next(self):
-        first_sub_task = self.sub_tasks[0]
-        next_sub_task = self.task.subtask_set.after(first_sub_task)
-        self.assertEqual(next_sub_task, self.sub_tasks[1])
+        next_sub_task = self.task.subtask_set.after(self.first_sub_task)
+        self.assertEqual(next_sub_task, self.middle_sub_task)
 
     def test_gets_previous(self):
-        last_sub_task = self.sub_tasks[2]
-        previous_sub_task = self.task.subtask_set.before(last_sub_task)
-        self.assertEqual(previous_sub_task, self.sub_tasks[1])
+        previous_sub_task = self.task.subtask_set.before(self.last_sub_task)
+        self.assertEqual(previous_sub_task, self.middle_sub_task)
 
     def test_returns_none_if_after_on_last(self):
-        last_sub_task = self.sub_tasks[2]
-        next_sub_task = self.task.subtask_set.after(last_sub_task)
+        next_sub_task = self.task.subtask_set.after(self.last_sub_task)
         self.assertIsNone(next_sub_task)
 
     def test_returns_none_if_previous_on_first(self):
-        first_sub_task = self.sub_tasks[0]
-        previous_sub_task = self.task.subtask_set.before(first_sub_task)
+        previous_sub_task = self.task.subtask_set.before(self.first_sub_task)
         self.assertIsNone(previous_sub_task)

--- a/orderable/tests/test_manager.py
+++ b/orderable/tests/test_manager.py
@@ -6,11 +6,7 @@ from .models import SubTask, Task
 class TestOrderableManager(TestCase):
     @classmethod
     def setUpTestData(cls):
-        tasks = []
-        for i in range(3):
-            task = Task(sort_order=i)
-            task.save()
-            tasks.append(task)
+        tasks = [Task.objects.create(sort_order=i) for i in range(3)]
         cls.first_task, cls.middle_task, cls.last_task = tasks
 
     def test_gets_next(self):
@@ -33,14 +29,11 @@ class TestOrderableManager(TestCase):
 class TestOrderableRelatedManager(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.task = Task()
-        cls.task.save()
+        cls.task = Task.objects.create()
 
-        sub_tasks = []
-        for i in range(3):
-            sub = SubTask(task=cls.task, sort_order=i)
-            sub.save()
-            sub_tasks.append(sub)
+        sub_tasks = [
+            SubTask.objects.create(task=cls.task, sort_order=i) for i in range(3)
+        ]
         cls.first_sub_task, cls.middle_sub_task, cls.last_sub_task = sub_tasks
 
     def test_gets_next(self):

--- a/orderable/tests/test_manager.py
+++ b/orderable/tests/test_manager.py
@@ -1,0 +1,66 @@
+from django.test import TestCase
+
+from .models import SubTask, Task
+
+
+class TestOrderableManager(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.tasks = []
+        for i in range(3):
+            task = Task(sort_order=i)
+            task.save()
+            cls.tasks.append(task)
+
+    def test_gets_next(self):
+        first_task = self.tasks[0]
+        next_task = Task.objects.after(first_task)
+        self.assertEqual(next_task, self.tasks[1])
+
+    def test_gets_previous(self):
+        last_task = self.tasks[2]
+        previous_task = Task.objects.before(last_task)
+        self.assertEqual(previous_task, self.tasks[1])
+
+    def test_returns_none_if_after_on_last(self):
+        last_task = self.tasks[2]
+        next_task = Task.objects.after(last_task)
+        self.assertIsNone(next_task)
+
+    def test_returns_none_if_previous_on_first(self):
+        first_task = self.tasks[0]
+        previous_task = Task.objects.before(first_task)
+        self.assertIsNone(previous_task)
+
+
+class TestOrderableRelatedManager(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.task = Task()
+        cls.task.save()
+
+        cls.sub_tasks = []
+        for i in range(3):
+            sub = SubTask(task=cls.task, sort_order=i)
+            sub.save()
+            cls.sub_tasks.append(sub)
+
+    def test_gets_next(self):
+        first_sub_task = self.sub_tasks[0]
+        next_sub_task = self.task.subtask_set.after(first_sub_task)
+        self.assertEqual(next_sub_task, self.sub_tasks[1])
+
+    def test_gets_previous(self):
+        last_sub_task = self.sub_tasks[2]
+        previous_sub_task = self.task.subtask_set.before(last_sub_task)
+        self.assertEqual(previous_sub_task, self.sub_tasks[1])
+
+    def test_returns_none_if_after_on_last(self):
+        last_sub_task = self.sub_tasks[2]
+        next_sub_task = self.task.subtask_set.after(last_sub_task)
+        self.assertIsNone(next_sub_task)
+
+    def test_returns_none_if_previous_on_first(self):
+        first_sub_task = self.sub_tasks[0]
+        previous_sub_task = self.task.subtask_set.before(first_sub_task)
+        self.assertIsNone(previous_sub_task)

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -212,6 +212,20 @@ class TestSubTask(TestCase):
         subtask_2.save()
         self.assertSequenceEqual(task.subtask_set.all(), [subtask, subtask_2])
 
+    def test_next_and_prev(self):
+        task = Task.objects.create()
+        task_2 = Task.objects.create()
+        subtask = SubTask.objects.create(task=task)
+        subtask_2 = SubTask.objects.create(task=task)
+        subtask_3 = SubTask.objects.create(task=task_2)
+
+        self.assertEqual(subtask.next(), subtask_2)
+        self.assertIsNone(subtask_2.next())
+
+        self.assertIsNone(subtask_3.prev())
+        self.assertIsNone(subtask_3.next())
+
+
     @given(lists(integers(min_value=1), min_size=1, unique=True))
     @example([2, 3, 1])
     @example([2, 3, 4])

--- a/orderable/tests/test_models.py
+++ b/orderable/tests/test_models.py
@@ -225,7 +225,6 @@ class TestSubTask(TestCase):
         self.assertIsNone(subtask_3.prev())
         self.assertIsNone(subtask_3.next())
 
-
     @given(lists(integers(min_value=1), min_size=1, unique=True))
     @example([2, 3, 1])
     @example([2, 3, 4])


### PR DESCRIPTION
@incuna/backend 

This adds the ability to find the next/previous item in an ordered queryset.

We were seeing the following pattern in a few projects:
`self.ordered_objects.filter(sort_order__gt=self.current_ordered_object.sort_order).first()`

This would be replaced with:
`self.ordered_objects.after(self.current_ordered_object)`

returning `None` if object doesn't exist.