### PR TITLE
Fix and improve admin ordering behaviour

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,12 @@
 
-Upcoming Changes
-================
+v5.0.0
+======
 
-* Drop support for django<1.8
-* Added before and after to the querset to return the next item in the set.
+* Drop support for django versions before 1.8.
+* Add `before` and `after` to `OrderableQueryset` to return the next item in the set.
     - example usage: `ordered_queryset.objects.after(ordered_object)`
+* Add `OrderableQueryset.set_orders()` to perform a mass rearrangement of items. This now requires custom model managers to inherit from `OrderableManager`.
+* Add `_pass_through_save()` to `Orderable`. This allows you to skip the insertion sorting performed by the `save()` method, such as when updating multiple objects at once to rearrange them. (`set_orders()` uses it.)
 
 v4.0.5
 ======

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ jQuery and jQuery UI are used in the Admin for the draggable UI. You may overrid
 
 ### Metaclasses
 
-If your subclass of Orderable has a Metaclass then make sure it subclasses the Orderable one so the model is sorted by ``sort_order``.
+If your subclass of Orderable has a Metaclass then make sure it subclasses the Orderable one so the model is sorted by `sort_order`.
+
+### Custom Managers
+
+Similarly, if your model has a custom manager, subclass `orderable.managers.OrderableManager` instead of `django.db.models.Manager`.
 
 ### Transactions
 

--- a/orderable/admin.py
+++ b/orderable/admin.py
@@ -55,12 +55,8 @@ class OrderableAdmin(admin.ModelAdmin):
             raise PermissionDenied
 
         if request.method == "POST":
-            neworder = 1
-            for object_id in request.POST.getlist('neworder[]'):
-                obj = model.objects.get(pk=object_id)
-                obj.sort_order = neworder
-                obj.save()
-                neworder += 1
+            object_pks = request.POST.getlist('neworder[]')
+            model.objects.set_orders(object_pks)
 
         return HttpResponse("OK")
 

--- a/orderable/managers.py
+++ b/orderable/managers.py
@@ -3,4 +3,9 @@ from django.db.models import Manager
 from .querysets import OrderableQueryset
 
 
+"""
+A manager for Orderables. If you customise your model's manager, be sure to inherit from
+this rather than django.db.models.Manager; it's required for the drag/drop ordering
+to work in the admin.
+"""
 OrderableManager = Manager.from_queryset(OrderableQueryset)

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -134,6 +134,13 @@ class Orderable(models.Model):
         # Call the "real" save() method.
         super(Orderable, self).save(*args, **kwargs)
 
+    def _pass_through_save(self, *args, **kwargs):
+        """
+        Skip the order fixing. Used for mass updates when you just need to write to
+        the sort_order field directly without any magic.
+        """
+        super(Orderable, self).save(*args, **kwargs)
+
     def sort_order_display(self):
         template = '<span id="neworder-{}" class="sorthandle">{}</span>'
         return template.format(self.id, self.sort_order)

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -134,13 +134,6 @@ class Orderable(models.Model):
         # Call the "real" save() method.
         super(Orderable, self).save(*args, **kwargs)
 
-    def _pass_through_save(self, *args, **kwargs):
-        """
-        Skip the order fixing. Used for mass updates when you just need to write to
-        the sort_order field directly without any magic.
-        """
-        super(Orderable, self).save(*args, **kwargs)
-
     def sort_order_display(self):
         template = '<span id="neworder-{}" class="sorthandle">{}</span>'
         return template.format(self.id, self.sort_order)

--- a/orderable/querysets.py
+++ b/orderable/querysets.py
@@ -15,7 +15,7 @@ class OrderableQueryset(models.QuerySet):
     def after(self, orderable):
         return self.filter(sort_order__gt=orderable.sort_order).first()
 
-    def set_orders(self, object_pks, *args, **kwargs):
+    def set_orders(self, object_pks):
         """
         Perform a mass update of sort_orders across the full queryset.
         Accepts a list, object_pks, of the intended order for the objects.

--- a/orderable/querysets.py
+++ b/orderable/querysets.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.db import models, transaction
 
 
 class OrderableQueryset(models.QuerySet):
@@ -7,11 +7,43 @@ class OrderableQueryset(models.QuerySet):
 
     Provides access to the next and previous ordered object within the queryset.
 
-    As a related manager this will provide the filtering automatically. Should you wish
-    to
+    As a related manager this will provide the filtering automatically.
     """
     def before(self, orderable):
         return self.filter(sort_order__lt=orderable.sort_order).last()
 
     def after(self, orderable):
         return self.filter(sort_order__gt=orderable.sort_order).first()
+
+    def set_orders(self, object_pks, *args, **kwargs):
+        """
+        Perform a mass update of sort_orders across the full queryset.
+        Accepts a list, object_pks, of the intended order for the objects.
+
+        Works as follows:
+        - Compile a list of all sort orders in the queryset.
+        - Get the maximum among all model object sort orders. Update the queryset to add
+          it to all the existing sort order values. This lifts them 'out of the way' of
+          unique_together clashes when setting the intended sort orders.
+        - Set the sort order on each object.
+        Performs O(n) queries.
+        """
+        orders = self.values_list('sort_order', flat=True)  # will be sorted
+        print(orders)
+        if len(object_pks) != len(orders):
+            raise TypeError(
+                'A list of object pks supplied to OrderableQueryset.set_orders() must ' +
+                'be of the same length as the queryset itself.'
+            )
+
+        max_value = self.model.objects.count()
+        self.update(sort_order=models.F('sort_order') + max_value)
+
+        with transaction.atomic():
+            for i, pk in enumerate(object_pks):
+                obj = self.get(pk=pk)
+                obj.sort_order = orders[i]
+                obj._pass_through_save()
+
+        # Return the operated-on queryset for convenience.
+        return self

--- a/orderable/querysets.py
+++ b/orderable/querysets.py
@@ -54,6 +54,8 @@ class OrderableQueryset(models.QuerySet):
         with transaction.atomic():
             objects_to_sort.update(sort_order=models.F('sort_order') + max_value)
             for pk, order in zip(object_pks, orders):
+                # Use update() to save a query per item and dodge the insertion sort
+                # code in save().
                 self.filter(pk=pk).update(sort_order=order)
 
         # Return the operated-on queryset for convenience.

--- a/orderable/querysets.py
+++ b/orderable/querysets.py
@@ -41,7 +41,9 @@ class OrderableQueryset(models.QuerySet):
         orders = list(objects_to_sort.values_list('sort_order', flat=True))
 
         # Check there are no unrecognised entries in the object_pks list. If so,
-        # throw an error.
+        # throw an error. We only have to check that they're the same length because
+        # orders is built using only entries in object_pks, and all the pks are unique,
+        # so if their lengths are the same, the elements must match up exactly.
         if len(orders) != len(object_pks):
             pks = set(objects_to_sort.values_list('pk', flat=True))
             message = 'The following object_pks are not in this queryset: {}'.format(

--- a/orderable/querysets.py
+++ b/orderable/querysets.py
@@ -44,4 +44,4 @@ class OrderableQueryset(models.QuerySet):
                 self.filter(pk=pk).update(sort_order=orders[i])
 
         # Return the operated-on queryset for convenience.
-        return self
+        return objects_to_sort

--- a/orderable/querysets.py
+++ b/orderable/querysets.py
@@ -43,8 +43,9 @@ class OrderableQueryset(models.QuerySet):
         # Check there are no unrecognised entries in the object_pks list. If so,
         # throw an error.
         if len(orders) != len(object_pks):
+            pks = set(objects_to_sort.values_list('pk', flat=True))
             message = 'The following object_pks are not in this queryset: {}'.format(
-                [pk for pk in object_pks if not objects_to_sort.filter(pk=pk).exists()]
+                [pk for pk in object_pks if pk not in pks]
             )
             raise TypeError(message)
 

--- a/orderable/querysets.py
+++ b/orderable/querysets.py
@@ -31,8 +31,10 @@ class OrderableQueryset(models.QuerySet):
           had before calling this method, so they get rearranged in place.
         Performs O(n) queries.
         """
-        max_value = self.model.objects.count()
         objects_to_sort = self.filter(pk__in=object_pks)
+        max_value = self.model.objects.all().aggregate(
+            models.Max('sort_order')
+        )['sort_order__max']
 
         # Call list() on the values right away, so they don't get affected by the
         # update() later (since values_list() is lazy).

--- a/orderable/tests/test_querysets.py
+++ b/orderable/tests/test_querysets.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+
+from .models import Task
+
+
+class TestOrderableQueryset(TestCase):
+    def test_set_orders(self):
+        """The sort_order values are rearranged effectively in-place."""
+        task_1 = Task.objects.create(sort_order=4, pk=1)
+        task_2 = Task.objects.create(sort_order=7, pk=2)
+
+        Task.objects.set_orders([2, 1])
+
+        task_1.refresh_from_db()
+        task_2.refresh_from_db()
+        self.assertEqual(task_1.sort_order, 7)
+        self.assertEqual(task_2.sort_order, 4)
+
+    def test_set_orders_wrong_pks(self):
+        """
+        When a pk is submitted that doesn't match an existing Task, we get a
+        descriptive error message.
+        """
+        Task.objects.create(sort_order=1, pk=1)
+
+        expected_msg = 'The following object_pks are not in this queryset: [2]'
+        with self.assertRaises(TypeError, msg=expected_msg):
+            Task.objects.set_orders([1, 2])
+
+    def test_set_orders_subset(self):
+        """
+        When only some Tasks are mentioned in the object_pks list, they're swapped around
+        and the others are unaffected.
+        """
+        task_1 = Task.objects.create(sort_order=1, pk=1)
+        task_2 = Task.objects.create(sort_order=4, pk=2)
+        task_3 = Task.objects.create(sort_order=5, pk=3)
+        task_4 = Task.objects.create(sort_order=8, pk=4)
+
+        Task.objects.set_orders([3, 2])
+
+        self.assertSequenceEqual(Task.objects.all(), [task_1, task_3, task_2, task_4])
+        self.assertSequenceEqual(
+            Task.objects.values_list('sort_order', flat=True),
+            [1, 4, 5, 8],
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 coverage==3.7.1
 django-discover-runner==1.0
 flake8==2.2.5
-flake8-docstrings==0.2.1
 flake8-import-order==0.5.3
 hypothesis==2.0.0
 psycopg2==2.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,6 @@
 universal = 1
 [flake8]
 application-import-names = orderable
-ignore = D100,D101,D102,D104,D105,D203,D204
 import-order-style = google
 max-complexity = 10
 max-line-length = 90

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='django-orderable',
     packages=find_packages(),
     include_package_data=True,
-    version='4.0.5',
+    version='5.0.0',
     description='Add manual sort order to Django objects via an abstract base '
                 'class and admin classes.',
     author='Incuna Ltd',


### PR DESCRIPTION
We've been seeing cases where dragging and dropping items in an admin list page just doesn't do anything (because the Ajax request returns a 500). This should fix that behaviour by ensuring the `sort_order` values can't clash and bypassing the insertion sort that `save()` performs.

@incuna/backend review please? :)