### PR TITLE
Fix `sort_order_display` in Django admin change_list view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+v5.0.1
+======
+
+* Fix `sort_order_display` in Django admin change_list view.
 
 v5.0.0
 ======

--- a/orderable/models.py
+++ b/orderable/models.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, models, transaction
+from django.utils.html import format_html
 
 from .managers import OrderableManager
 
@@ -135,8 +136,11 @@ class Orderable(models.Model):
         super(Orderable, self).save(*args, **kwargs)
 
     def sort_order_display(self):
-        template = '<span id="neworder-{}" class="sorthandle">{}</span>'
-        return template.format(self.id, self.sort_order)
+        return format_html(
+            '<span id="neworder-{}" class="sorthandle">{}</span>',
+            self.id, self.sort_order,
+        )
+
     sort_order_display.allow_tags = True
     sort_order_display.short_description = 'Order'
     sort_order_display.admin_order_field = 'sort_order'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ django-discover-runner==1.0
 flake8==2.2.5
 flake8-import-order==0.5.3
 hypothesis==2.0.0
-psycopg2==2.6.1
+psycopg2==2.7.4

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='django-orderable',
     packages=find_packages(),
     include_package_data=True,
-    version='5.0.0',
+    version='5.0.1',
     description='Add manual sort order to Django objects via an abstract base '
                 'class and admin classes.',
     author='Incuna Ltd',


### PR DESCRIPTION
Django 2 does care if change_list labels are html safe or not. If they are not, they will be escaped, which breaks the package currently with Django 2. This should fix it 👍 