### PR TITLE
Ensure that the sort_order increases.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+UPCOMING
+========
+
+* Fix edit inline issues causing reordering to fail when items have equal sort_order values.
+
 v6.0.0
 ======
 

--- a/orderable/templates/admin/edit_inline/orderable_tabular.html
+++ b/orderable/templates/admin/edit_inline/orderable_tabular.html
@@ -19,12 +19,14 @@
 $(document).ready(function() {
 
     var order_array = [];
+    var min_value = 0;
     $("#{{ inline_admin_formset.formset.prefix }}-group .tabular.inline-related tbody tr.has_original td.field-sort_order :input").each(function() {
-            var id = $(this).val();
-            order_array.push(id);
-            $(this).parent().append("<span id='{{ inline_admin_formset.formset.prefix }}-neworder-" + id + "' class='sorthandle'>Order</span>");;
-            $(this).hide();
-        });
+        var id = Math.max(min_value, $(this).val());  // Ensure that the values increase.
+        min_value = id + 1;
+        order_array.push(id);
+        $(this).parent().append("<span id='{{ inline_admin_formset.formset.prefix }}-neworder-" + id + "' class='sorthandle'>Order</span>");;
+        $(this).hide();
+    });
 
 
     // Steal the draghandle's id and apply to the row


### PR DESCRIPTION
I encountered a bug using the drag and drop edit inline admin when items have the same `sort_order` value. The issue being simply that if your reorder equal values, the items remain in the same order.

To address this I updated the JavaScript code to ensure that each `sort_order` value is always at least 1 more than the previous value.

There is a wider question of how the items in a list have the same `sort_order`, but I found it was not hard to get into this situation.