### PR TITLE
Fixed: UUID as Primary key 

### DIFF
--- a/orderable/models.py
+++ b/orderable/models.py
@@ -154,7 +154,7 @@ class Orderable(models.Model):
 
     def sort_order_display(self):
         return format_html(
-            '<span id="neworder-{}" class="sorthandle">{}</span>',
+            '<span id="neworder_{}" class="sorthandle">{}</span>',
             self.id, self.sort_order,
         )
 

--- a/orderable/templates/admin/orderable_change_list.html
+++ b/orderable/templates/admin/orderable_change_list.html
@@ -49,7 +49,7 @@
                 'forcePlaceholderSize': true,
                 'update': function(sorted) {
 
-                    var cereal = $(this).sortable("serialize");
+                    var cereal = $(this).sortable("serialize", {expression:(/(.+)[_](.+)/)});
                     cereal += '&csrfmiddlewaretoken=' + $("input[name=csrfmiddlewaretoken]").val();
 
                     var classflip = 1;


### PR DESCRIPTION
For [UUID](https://docs.djangoproject.com/en/dev/ref/models/fields/#uuidfield) like **876e45a4-6a27-4f7b-95ca-9e2500f11801**  The [serialize ](https://api.jqueryui.com/sortable/#method-serialize) method of **JQueryUI Sortable** doesn't serialize list as expected. 



