### PR TITLE
Change staticfiles to static

### DIFF
--- a/orderable/templates/admin/orderable_change_list.html
+++ b/orderable/templates/admin/orderable_change_list.html
@@ -1,6 +1,6 @@
 {% extends "admin/change_list.html" %}
 
-{% load staticfiles %}
+{% load static %}
 
 {% block extrastyle %}
 {{ block.super }}


### PR DESCRIPTION
Templatetag "static" works for all recent django versions and "staticfiles" is removed in django 3.0