### PR TITLE
Fix a missed instance of `staticfiles`

### DIFF
--- a/orderable/templates/admin/edit_inline/orderable_tabular.html
+++ b/orderable/templates/admin/edit_inline/orderable_tabular.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 {% include "admin/edit_inline/tabular.html" %}
 


### PR DESCRIPTION
Django 3.0 requires use of `static` over `staticfiles`. This has been updated for the main admin display template, but not the inline one.

(Also, hi folks, it's been a while :P)